### PR TITLE
- Alters 2 database objects to ensure email addresses are trimmed whe…

### DIFF
--- a/CI/SQL/20180326_152400_US12478-api-crds-get-mp-contact-updates-for-hubspot-stored-proc.sql
+++ b/CI/SQL/20180326_152400_US12478-api-crds-get-mp-contact-updates-for-hubspot-stored-proc.sql
@@ -16,8 +16,8 @@ as
     with EmailAddressAuditLog as (
         select          MostRecentFieldChanges.RecordId as UserId,
                         'email' as PropertyName, -- the value of the "PropertyName" column corresponds to the "property name" used in HubSpot (passed along in the HS API payload)
-                        InitialEmailChangeAuditLog.PreviousValue,
-                        LatestEmailChangeAuditLog.NewValue
+                        trim(InitialEmailChangeAuditLog.PreviousValue) as PreviousValue,
+                        trim(LatestEmailChangeAuditLog.NewValue) as NewValue
 
         from            (
                             select          MostRecentEmailChange.RecordId,

--- a/CI/SQL/20180502_111904_US12482-vw-crds-hubspot-users.sql
+++ b/CI/SQL/20180502_111904_US12482-vw-crds-hubspot-users.sql
@@ -11,7 +11,7 @@ as
                         dp_Users.[User_ID] as UserId,                                                                           -- NOT HubSpot
                         Contacts.Household_ID as HouseholdId,                                                                   -- NOT HubSpot
                         Contacts.Contact_ID as MinistryPlatformContactId,                                                       -- HubSpot ▼ ▼ ▼ (everything here and below matches to a HubSpot contact attribute identifier)
-                        dp_Users.[User_Name] as Email,                                                                          -- switched to dp_Users.User_Name based on dbo.crds_service_update_email_nightly
+                        trim(dp_Users.[User_Name]) as Email,                                                                    -- switched to dp_Users.User_Name based on dbo.crds_service_update_email_nightly
                         Contacts.Nickname as Firstname,
                         Contacts.Last_Name as Lastname,
                         isnull(Congregations.Congregation_Name, '') as Community,


### PR DESCRIPTION
…n queried for Ministry Platform --> HubSpot processing

  - this should allow otherwise-legitimate email addresses (w/ surrounding white space that would have previously been denied by HubSpot email validation) to be added to HubSpot
  - vw-crds-hubspot-users.sql: database view responsible for identifying hubspot candidates; underpins most mp-to-hubspot queries
  - api-crds-get-mp-contact-updates-for-hubspot-stored-proc.sql: stored procedure responsible for searching the audit log for changes